### PR TITLE
Added a command line util for demonstration / interacting with SCD4x

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,12 @@
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "arm-linux-musleabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,28 @@ edition = "2018"
 
 [features]
 scd41 = []
+util = [ "structopt", "simplelog", "humantime", "linux-embedded-hal", "anyhow" ]
+default = [ "util" ]
 
 [dependencies]
 sensirion-i2c = "0.1"
 embedded-hal = "0.2"
 
+log = { version = "0.4.16", default_features = false }
+defmt = { version = "0.3.0", optional = true }
+anyhow = { version = "1.0.56", optional=true, default_features = false }
+
+structopt = { version = "0.3.26", optional = true }
+linux-embedded-hal = { version = "0.3.2", optional = true }
+simplelog = { version = "0.12.0", optional = true }
+humantime = { version = "2.1.0", optional = true }
+
+
 [dev-dependencies]
 linux-embedded-hal = "0.3"
 embedded-hal-mock = "0.8"
+
+[[bin]]
+name = "scd4x-util"
+path = "src/main.rs"
+required-features = ["util"]

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -2,7 +2,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use hal::{Delay, I2cdev};
 use linux_embedded_hal as hal;
 
-use scd4x::scd4x::Scd4x;
+use scd4x::Scd4x;
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,16 +3,22 @@ use hal::blocking::i2c::{Read, Write};
 use sensirion_i2c::i2c;
 
 /// SCD4X errors
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error<E> {
+    #[cfg_attr(feature = "thiserror", error("I2C: {0}"))]
     /// I²C bus error
     I2c(E),
+    #[cfg_attr(feature = "thiserror", error("CRC"))]
     /// CRC checksum validation failed
     Crc,
+    #[cfg_attr(feature = "thiserror", error("Self Test"))]
     /// Self-test measure failure
     SelfTest,
+    #[cfg_attr(feature = "thiserror", error("Not Allowed"))]
     /// Not allowed when periodic measurement is running
     NotAllowed,
+    #[cfg_attr(feature = "thiserror", error("Internal"))]
     /// Internal fail
     Internal
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,24 @@
 #![deny(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 
+/// Log functions for internal use, use `crate::log::*`
+mod log {
+    // Default to logging with log
+    #[cfg(not(feature = "defmt"))]
+    pub use log::{trace, debug, info, warn, error};
+
+    // Replace with defmt if enabled
+    #[cfg(feature = "defmt")]
+    pub use defmt::{trace, debug, info, warn, error};
+}
+
+
+mod scd4x;
+pub use scd4x::Scd4x;
+
+mod error;
+pub use error::Error;
+
 pub mod commands;
-pub mod error;
-pub mod scd4x;
+
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod log {
 
 
 mod scd4x;
-pub use scd4x::Scd4x;
+pub use crate::scd4x::Scd4x;
 
 mod error;
 pub use error::Error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,104 @@
+use embedded_hal::blocking::delay::DelayMs;
+use hal::{Delay, I2cdev, i2cdev::linux::LinuxI2CError};
+use linux_embedded_hal as hal;
+
+use log::{debug, info, error};
+
+use structopt::StructOpt;
+use humantime::{Duration as HumanDuration};
+use simplelog::{TermLogger, LevelFilter};
+
+use scd4x::{Scd4x, Error};
+
+
+#[derive(StructOpt)]
+#[structopt(name = "scd4x-util")]
+/// A Command Line Interface (CLI) for interacting with a sensiron SCD4x environmental sensor via Linux I2C
+pub struct Options {
+
+    /// Specify the i2c interface to use to connect to the scd30 device
+    #[structopt(short="d", long = "i2c", default_value = "/dev/i2c-1", env = "SCD4x_I2C")]
+    i2c: String,
+
+    /// Delay between sensor poll operations
+    #[structopt(long = "poll-delay", default_value="100ms")]
+    pub poll_delay: HumanDuration,
+
+    /// Number of allowed I2C errors (per measurement attempt) prior to exiting
+    #[structopt(long = "allowed-errors", default_value="3")]
+    pub allowed_errors: usize,
+
+    /// Enable verbose logging
+    #[structopt(long = "log-level", default_value = "info")]
+    level: LevelFilter,
+}
+
+
+fn main() -> Result<(), Error<LinuxI2CError>> {
+
+    // Load options
+    let opts = Options::from_args();
+
+    // Setup logging
+    TermLogger::init(opts.level, 
+        simplelog::Config::default(),
+        simplelog::TerminalMode::Mixed,
+        simplelog::ColorChoice::Auto).unwrap();
+
+    debug!("Connecting to I2C device");
+    let i2c = match I2cdev::new(&opts.i2c) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Error opening I2C device '{}': {:?}", &opts.i2c, e);
+            std::process::exit(-1);
+        }
+    };
+
+    debug!("Connecting to sensor");
+    let mut sensor = Scd4x::new(i2c, Delay);
+
+
+    debug!("Initalising sensor");
+
+    sensor.wake_up();
+    sensor.stop_periodic_measurement()?;
+    sensor.reinit()?;
+
+    let serial = sensor.serial_number()?;
+    info!("Serial: {:#04x}", serial);
+
+    debug!("Starting periodic measurement");
+    sensor.start_periodic_measurement()?;
+
+    debug!("Waiting for first measurement... (5 sec)");
+
+    loop {
+        hal::Delay.delay_ms(5000u16);
+
+        debug!("Waiting for data ready");
+        loop {
+            match sensor.data_ready_status() {
+                Ok(true) => break,
+                Ok(false) => std::thread::sleep(*opts.poll_delay),
+                Err(e) => {
+                    error!("Failed to poll for data ready: {:?}", e);
+                    std::process::exit(-2);
+                },
+            }
+        }
+
+        debug!("Reading sensor data");
+        let data = match sensor.measurement() {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to read measurement: {:?}", e);
+                std::process::exit(-3);
+            },
+        };
+
+        println!(
+            "CO2: {0}, Temperature: {1:#.2} °C, Humidity: {2:#.2} RH",
+            data.co2, data.temperature, data.humidity
+        );
+    }
+}


### PR DESCRIPTION
hey there, thanks for making a neat library! i customarily add a utility to my [drivers](https://github.com/ryankurte/rust-sensor-scd30) which in my experience is handy both as an example and to quickly get started with / test devices, and i needed one for this so i thought i would open a PR ^_^

this makes a couple of other changes too:
- adds `log` and `defmt` support (though this is not yet used in the library)
- adds `anyhow` support behind a feature of the same name so `Error: std::error::Error`
- moves exports for `Scd4x` and `Error` to crate root so users can `use scd4x::{Sxd4x, Error}`

i also tend to setup [CI](https://github.com/ryankurte/rust-sensor-scd30/blob/master/.github/workflows/rust.yml) to auto-build and release the utility for a collection of platforms, happy to open another PR with this if you're interested