### PR TITLE
Gate low power commands behind scd41 feature

### DIFF
--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -8,6 +8,7 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let mut sensor = Scd4x::new(dev, Delay);
 
+    #[cfg(feature = "scd41")]
     sensor.wake_up();
     sensor.stop_periodic_measurement().unwrap();
     sensor.reinit().unwrap();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -48,10 +48,13 @@ pub enum Command {
     #[cfg(feature = "scd41")]
     MeasureSingleShot,
     /// On-demand measurement of CO2 concentration, relative humidity and temperature.
+    #[cfg(feature = "scd41")]
     MeasureSingleShotRhtOnly,
     /// Put the sensor from idle to sleep mode to reduce current consumption.
+    #[cfg(feature = "scd41")]
     PowerDown,
     /// Wake up sensor from sleep mode to idle mode.
+    #[cfg(feature = "scd41")]
     WakeUp,
 }
 
@@ -79,8 +82,11 @@ impl Command {
             Self::Reinit => (0x3646, 20, false),
             #[cfg(feature = "scd41")]
             Self::MeasureSingleShot => (0x219D, 5000, false),
+            #[cfg(feature = "scd41")]
             Self::MeasureSingleShotRhtOnly => (0x2196, 50, false),
+            #[cfg(feature = "scd41")]
             Self::PowerDown => (0x36E0, 1, false),
+            #[cfg(feature = "scd41")]
             Self::WakeUp => (0x36F6, 20, false),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), Error<LinuxI2CError>> {
 
     debug!("Initalising sensor");
 
+    #[cfg(feature = "scd41")]
     sensor.wake_up();
     sensor.stop_periodic_measurement()?;
     sensor.reinit()?;

--- a/src/scd4x.rs
+++ b/src/scd4x.rs
@@ -203,27 +203,30 @@ where
         Ok(())
     }
 
-    /// On-demand measurement of CO₂ concentration, relative humidity and temperature. 
+    /// On-demand measurement of CO₂ concentration, relative humidity and temperature.
     /// The sensor output is read with the measurement method.
     #[cfg(feature = "scd41")]
-    pub fn measure_single_shot(&mut self) -> Result<(), Error<E>>{
+    pub fn measure_single_shot(&mut self) -> Result<(), Error<E>> {
         self.write_command(Command::MeasureSingleShot)?;
         Ok(())
     }
 
     /// On-demand measurement of relative humidity and temperature only.
-    pub fn measure_single_shot_rht(&mut self) ->Result<(), Error<E>> {
+    #[cfg(feature = "scd41")]
+    pub fn measure_single_shot_rht(&mut self) -> Result<(), Error<E>> {
         self.write_command(Command::MeasureSingleShotRhtOnly)?;
         Ok(())
     }
 
     /// Put the sensor from idle to sleep mode to reduce current consumption.
-    pub fn power_down(&mut self) -> Result<(), Error<E>>{
+    #[cfg(feature = "scd41")]
+    pub fn power_down(&mut self) -> Result<(), Error<E>> {
         self.write_command(Command::PowerDown)?;
         Ok(())
     }
 
     /// Wake up sensor from sleep mode to idle mode.
+    #[cfg(feature = "scd41")]
     pub fn wake_up(&mut self) {
         // Sensor does not acknowledge the wake-up call, error is ignored
         self.write_command(Command::WakeUp).ok();
@@ -306,25 +309,25 @@ mod tests {
         assert_eq!(serial, 0xbeefbeefbeef);
     }
 
-     /// Test the measurement function
-     #[test]
-     fn test_measurement() {
-         // Arrange
-         let (cmd, _, _) = Command::ReadMeasurement.as_tuple();
-         let expectations = [
-             Transaction::write(SCD4X_I2C_ADDRESS, cmd.to_be_bytes().to_vec()),
-             Transaction::read(
-                 SCD4X_I2C_ADDRESS,
-                 vec![0x03, 0xE8, 0xD4, 0x62, 0x03, 0x5E, 0x80, 0x00, 0xA2],
-             ),
-         ];
-         let mock = I2cMock::new(&expectations);
-         let mut sensor = Scd4x::new(mock, DelayMock);
-         // Act
-         let data = sensor.measurement().unwrap();
-         // Assert
-         assert_eq!(data.co2, 1000_u16);
-         assert_eq!(data.temperature, 22.000198_f32);
-         assert_eq!(data.humidity, 50_f32);
-     }
+    /// Test the measurement function
+    #[test]
+    fn test_measurement() {
+        // Arrange
+        let (cmd, _, _) = Command::ReadMeasurement.as_tuple();
+        let expectations = [
+            Transaction::write(SCD4X_I2C_ADDRESS, cmd.to_be_bytes().to_vec()),
+            Transaction::read(
+                SCD4X_I2C_ADDRESS,
+                vec![0x03, 0xE8, 0xD4, 0x62, 0x03, 0x5E, 0x80, 0x00, 0xA2],
+            ),
+        ];
+        let mock = I2cMock::new(&expectations);
+        let mut sensor = Scd4x::new(mock, DelayMock);
+        // Act
+        let data = sensor.measurement().unwrap();
+        // Assert
+        assert_eq!(data.co2, 1000_u16);
+        assert_eq!(data.temperature, 22.000198_f32);
+        assert_eq!(data.humidity, 50_f32);
+    }
 }


### PR DESCRIPTION
According to the
[datasheet](https://sensirion.com/media/documents/E0F04247/631EF271/CD_DS_SCD40_SCD41_Datasheet_D1.pdf) the commands in the "low power single shot" section are only available for the scd41.
See page 8/24.