### PR TITLE
Add non-blocking single-shot measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scd4x"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Hauke Jung <hauke.jung@outlook.de>"]
 documentation = "https://docs.rs/scd4x"
 repository = "https://github.com/hauju/scd4x-rs.git"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,6 +47,9 @@ pub enum Command {
     /// Allows on-demand measurements
     #[cfg(feature = "scd41")]
     MeasureSingleShot,
+    /// Allows on-demand, non-blocking measurements
+    #[cfg(feature = "scd41")]
+    MeasureSingleShotNonBlocking,
     /// On-demand measurement of CO2 concentration, relative humidity and temperature.
     MeasureSingleShotRhtOnly,
     /// Put the sensor from idle to sleep mode to reduce current consumption.
@@ -79,6 +82,8 @@ impl Command {
             Self::Reinit => (0x3646, 20, false),
             #[cfg(feature = "scd41")]
             Self::MeasureSingleShot => (0x219D, 5000, false),
+            #[cfg(feature = "scd41")]
+            Self::MeasureSingleShotNonBlocking => (0x219D, 1, false),
             Self::MeasureSingleShotRhtOnly => (0x2196, 50, false),
             Self::PowerDown => (0x36E0, 1, false),
             Self::WakeUp => (0x36F6, 20, false),

--- a/src/scd4x.rs
+++ b/src/scd4x.rs
@@ -205,9 +205,19 @@ where
 
     /// On-demand measurement of CO₂ concentration, relative humidity and temperature. 
     /// The sensor output is read with the measurement method.
+    /// Takes around 5 seconds to complete
     #[cfg(feature = "scd41")]
     pub fn measure_single_shot(&mut self) -> Result<(), Error<E>>{
         self.write_command(Command::MeasureSingleShot)?;
+        Ok(())
+    }
+
+    /// On-demand measurement of CO₂ concentration, relative humidity and temperature.
+    /// The sensor output is read with the measurement method.
+    /// Completes immediately, but the measurement can only be read after 5 seconds.
+    #[cfg(feature = "scd41")]
+    pub fn measure_single_shot_non_blocking(&mut self) -> Result<(), Error<E>> {
+        self.write_command(Command::MeasureSingleShotNonBlocking)?;
         Ok(())
     }
 


### PR DESCRIPTION
...useful for async code.

Although the `measure_single_shot` cmd has an execution time of 5 secs, we can do other stuff in the meantime and come back to collect the sample after 5 seconds. This should be legal according to the chip datasheet, and seems to work in my test setup here.