### PR TITLE
Add ASC target CO2 level getters and setters

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -27,6 +27,10 @@ pub enum Command {
     SetAutomaticSelfCalibrationEnabled,
     /// Get the current state of the automatic self-calibration.
     GetAutomaticSelfCalibrationEnabled,
+    /// Set the target background (lower-bound) CO2 level the sensor expects to measure
+    SetAutomaticSelfCalibrationTarget,
+    /// Get the target background (lower-bound) CO2 level
+    GetAutomaticSelfCalibrationTarget,
     /// Start low power periodic measurement, signal update interval is approximately 30 seconds.
     StartLowPowerPeriodicMeasurement,
     /// Is data ready for read-out?
@@ -76,6 +80,8 @@ impl Command {
             Self::PerformForcedRecalibration => (0x362F, 400, false),
             Self::SetAutomaticSelfCalibrationEnabled => (0x2416, 1, false),
             Self::GetAutomaticSelfCalibrationEnabled => (0x2313, 1, false),
+            Self::SetAutomaticSelfCalibrationTarget => (0x243A, 1, false),
+            Self::GetAutomaticSelfCalibrationTarget => (0x233F, 1, false),
             Self::StartLowPowerPeriodicMeasurement => (0x21AC, 0, false),
             Self::GetDataReadyStatus => (0xE4B8, 1, true),
             Self::PersistSettings => (0x3615, 800, false),

--- a/src/scd4x.rs
+++ b/src/scd4x.rs
@@ -127,6 +127,20 @@ where
         Ok(())
     }
 
+    /// Get the current background CO2 level the sensor is configured to expect. Factory default is 400 ppm.
+    pub fn automatic_self_calibration_target(&mut self) -> Result<u16, Error<E>> {
+        let mut buf = [0; 3];
+        self.delayed_read_cmd(Command::GetAutomaticSelfCalibrationTarget, &mut buf)?;
+        let ppm = u16::from_be_bytes([buf[0], buf[1]]);
+        Ok(ppm)
+    }
+
+    /// Set the background CO2 level the sensor should expect to measure
+    pub fn set_automatic_self_calibration_target(&mut self, ppm: u16) -> Result<(), Error<E>> {
+        self.write_command_with_data(Command::SetAutomaticSelfCalibrationTarget, ppm)?;
+        Ok(())
+    }
+
     /// Start low power periodic measurements
     pub fn start_low_power_periodic_measurements(&mut self) -> Result<(), Error<E>> {
         self.write_command(Command::StartLowPowerPeriodicMeasurement)?;


### PR DESCRIPTION
This simple commit adds two missing commands which exist in the original SCD4x SDK but were missing from the Rust driver. `set_automatic_self_calibration_target` & `get_automatic_self_calibration_target`, as they're named in the datasheet, allow the programmer to set the target background (lower-bound) CO2 concentration that the automatic self-calibration algorithm bases its assumptions on (see section 3.8.4 & 3.8.5 in the datasheet).

This PR adds two command descriptions to the enum and implements two new public functions to the Scd4x struct: `automatic_self_calibration_target` & `set_automatic_self_calibration_target`, in theme with the naming conventions of our other functions vs. the official SDK.

From the factory these sensors ship with a target of 400 ppm (see section 3.8.5) which may have been fine at the time of R&D, but has now risen to an average of ~427 ppm globally.

I believe since this is a new feature added this warrants a new 0.4.1 release but I shall leave the bumping of version numbers to you, @hauju :)