### PR TITLE
Fix SCD4x datasheet link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library provides an embedded `no_std` driver for the [Sensirion SCD4x serie
 
 The SCD4x is a miniature carbon dioxide sensor. It also measure temperature and relative humidity.
 
-Further information: [Datasheet CO2 Sensor SCD4x](https://sensirion.com/media/documents/48C4B7FB/66E05452/CD_DS_SCD4x_Datasheet_D1.pdf)
+Further information: [Datasheet CO2 Sensor SCD4x](https://sensirion.com/media/documents/48C4B7FB/67FE0194/CD_DS_SCD4x_Datasheet_D1.pdf)
 
 ## Usage
 


### PR DESCRIPTION
The link to the datasheet in the README is broken. This PR fixes it.